### PR TITLE
fix npm module name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kaakaa/slidaiv",
+  "name": "slidaiv",
   "displayName": "Slidaiv",
   "description": "Slidaiv extension leverages AI/LLM to automatically generate content for Slidev presentations, making it easier for users to write a Slidev presentation.",
   "publisher": "kaakaa",


### PR DESCRIPTION
## Summary

Revert npm module name without scope in order to fix the error for building vscode extension.
https://github.com/kaakaa/slidaiv/actions/runs/10491729749/job/29061545404#step:6:15