### PR TITLE
add banner shebang to run slidaiv-cli as npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "vscode-test",
-    "cli:compile": "esbuild src/cli/main.ts --bundle --platform=node --format=cjs --outfile=dist/slidaiv-cli.js",
+    "cli:compile": "esbuild src/cli/main.ts --bundle --platform=node --format=cjs --outfile=dist/slidaiv-cli.js --banner:js='#!/usr/bin/env node'",
     "mock-server": "prism mock -d ./e2e/mock-openai.yaml"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Add banner `#!/usr/bin/env node` to esbuild command to fix slidav-cli error.

```bash
$ npm i slidaiv
$ npx slidaiv --help
~/cli-test/node_modules/.bin/slidaiv: line 1: use strict: command not found
~/cli-test/node_modules/.bin/slidaiv: line 2: var: command not found
~/cli-test/node_modules/.bin/slidaiv: line 3: var: command not found
~/cli-test/node_modules/.bin/slidaiv: line 4: var: command not found
~/cli-test/node_modules/.bin/slidaiv: line 5: var: command not found
~/cli-test/node_modules/.bin/slidaiv: line 6: var: command not found
~/cli-test/node_modules/.bin/slidaiv: line 7: var: command not found
~/cli-test/node_modules/.bin/slidaiv: line 8: syntax error near unexpected token `('
~/cli-test/node_modules/.bin/slidaiv: line 8: `var __esm = (fn, res) => function __init() {'
```